### PR TITLE
Solved Custom schema remember previous value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export function validator (name, fn) {
 export function middleware (schema, options) {
   return function (req, res, next) {
     let _schema = schema instanceof Schema
-                ? _.clone(schema)
+                ? _.cloneDeep(schema)
                 : new Schema(schema, options)
 
     _schema.validate(req.query, (err) => {


### PR DESCRIPTION
Solved problem described in https://github.com/diegohaz/querymen/issues/30

Now querymen.middleware(schema) do a deep clone of the base schema, so when you apply modifications to _schema for a query, that do not edit the base schema.

Thanks!!