### PR TITLE
Change keyword to use $text search instead

### DIFF
--- a/src/querymen-schema.js
+++ b/src/querymen-schema.js
@@ -24,9 +24,9 @@ export default class QuerymenSchema {
     }
     this._params = {
       q: {
-        type: RegExp,
-        normalize: true,
-        paths: ['keywords']
+        type: String,
+        paths: ['$text'],
+        operator: "$search"
       },
       fields: {
         type: [String],

--- a/src/querymen-schema.js
+++ b/src/querymen-schema.js
@@ -26,7 +26,7 @@ export default class QuerymenSchema {
       q: {
         type: String,
         paths: ['$text'],
-        operator: "$search"
+        operator: '$search'
       },
       fields: {
         type: [String],

--- a/test/querymen-schema.js
+++ b/test/querymen-schema.js
@@ -136,7 +136,7 @@ test('QuerymenSchema name', (t) => {
 
 test('QuerymenSchema default parse', (t) => {
   let parse = (...args) => schema().parse(...args)
-  t.same(parse({q: 'testing'}).query.keywords, /testing/i, 'should parse q')
+  t.same(parse({ q: 'testing' }).query, { $text: { $search: 'testing' } }, 'should parse q')
   t.same(parse().select, {}, 'should not parse undefined select')
   t.same(parse({fields: ''}).select, {}, 'should not parse empty select')
   t.same(parse({fields: 'a'}).select, {a: 1}, 'should parse one select')


### PR DESCRIPTION
Hi everyone! 

I tried to use q to my do searches and I realized that `q` query string is _reserved_ . Checking keyword plugin, MAYBE is quite deprecated due to  mongo $text index.

Here's a pull request to substitute keywords to $text

I managed overwriting it in my route, but could be nice to have this as default.


