### PR TITLE
Fix convert `$in` operators with single value to array

### DIFF
--- a/src/querymen-param.js
+++ b/src/querymen-param.js
@@ -23,6 +23,9 @@ export default class QuerymenParam extends Param {
         } else if (_.isRegExp(value)) {
           return operator === '$ne' ? {[path]: {$not: value}} : {[path]: value}
         } else {
+          if (_.includes(['$in', '$nin'], operator) && !_.isArray(value)) {
+            return {[path]: {[operator]: [value]}}
+          }
           return {[path]: {[operator]: value}}
         }
       }

--- a/test/querymen-param.js
+++ b/test/querymen-param.js
@@ -156,6 +156,8 @@ test('QuerymenParam parse', (t) => {
   t.same(parse(123, {operator: '$gt'}), {test: {$gt: 123}}, 'should parse $gt')
   t.same(parse(123, {operator: '$gte'}), {test: {$gte: 123}}, 'should parse $gte')
   t.same(parse(123, {operator: '$lt'}), {test: {$lt: 123}}, 'should parse $lt')
+  t.same(parse(123, {operator: '$in'}), {test: {$in: [123]}}, 'should parse $in value to array')
+  t.same(parse(123, {operator: '$nin'}), {test: {$nin: [123]}}, 'should parse $nin value to array')
   t.same(parse(123, {operator: '$lte'}), {test: {$lte: 123}}, 'should parse $lte')
   t.same(parse(/test/i, {operator: '$ne'}), {test: {$not: /test/i}}, 'should parse $not')
   t.same(parse(123, {parse: (value, path, operator) => ({[path]: operator})}), {test: '$eq'}, 'should parse option')


### PR DESCRIPTION
As an example
```js
import { middleware as query } from 'querymen';

app.get('/posts', query({
  categories: {
    type: [String],
    operator: '$in'
  }
}));

// User requests /posts?categories=test querymen before would return:
// { categories: { $in: 'test' } }

// Now:
// { categories: { $in: ['test'] } }
```